### PR TITLE
[FIX] website_crm : impossible to add a crm form

### DIFF
--- a/addons/website_crm/static/src/js/website_crm_editor.js
+++ b/addons/website_crm/static/src/js/website_crm_editor.js
@@ -52,6 +52,7 @@ FormEditorRegistry.add('create_lead', {
         name: 'user_id',
         type: 'many2one',
         relation: 'res.users',
+        domain: [['share', '=', false]],
         string: _t('Salesperson'),
         title: _t('Assign leads/opportunities to a salesperson.'),
     }],


### PR DESCRIPTION
In large database with lot of user, the browser don't respond.

closes odoo/odoo#106638

X-original-commit: 0f597b3a9c4110d2984000c21564cc95e61491c4
Signed-off-by: Romain Derie (rde) <rde@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
