### PR TITLE
[FIX] event_sale: division by 0 on price

### DIFF
--- a/addons/event_sale/report/event_sale_report.py
+++ b/addons/event_sale/report/event_sale_report.py
@@ -100,12 +100,20 @@ SELECT
     sale_order.user_id AS sale_order_user_id,
     
     sale_order_line.product_id AS product_id,
-    sale_order_line.price_total
-        / CASE COALESCE(sale_order.currency_rate, 0) WHEN 0 THEN 1.0 ELSE sale_order.currency_rate END
-        / sale_order_line.product_uom_qty AS sale_price,
-    sale_order_line.price_subtotal
-        / CASE COALESCE(sale_order.currency_rate, 0) WHEN 0 THEN 1.0 ELSE sale_order.currency_rate END
-        / sale_order_line.product_uom_qty AS sale_price_untaxed,
+    CASE
+        WHEN sale_order_line.product_uom_qty = 0 THEN 0
+        ELSE
+        sale_order_line.price_total
+            / CASE COALESCE(sale_order.currency_rate, 0) WHEN 0 THEN 1.0 ELSE sale_order.currency_rate END
+            / sale_order_line.product_uom_qty
+    END AS sale_price,
+    CASE
+        WHEN sale_order_line.product_uom_qty = 0 THEN 0
+        ELSE
+        sale_order_line.price_subtotal
+            / CASE COALESCE(sale_order.currency_rate, 0) WHEN 0 THEN 1.0 ELSE sale_order.currency_rate END
+            / sale_order_line.product_uom_qty
+        END AS sale_price_untaxed,
     CASE
         WHEN sale_order_line.price_total = 0 THEN 'free'
         WHEN event_registration.is_paid THEN 'paid'


### PR DESCRIPTION
When you have some order lines linked to a registration that have a 'product_uom_qty' equals to 0, you get a division by 0 error when you try to get the 'sale_price' and the 'sale_price_untaxed'.

To avoid such issue, we are now checking if the 'product_uom_qty' is not equals to 0 to avoid a division by 0. In the case it is equal to 0, we consider that the 'sale_price' and 'sale_price_untaxed' are equal to 0 as nothing has been paid for this registration.

To reproduce you can do like this:
- create invite someone to your event
- create a SO with qty 1 and the price
- validate the SO and select the registration
- set product_uom_qty to 0 in the SO
- open the event dashboard (and remove the filter to get your event)

closes odoo/odoo#108297

Signed-off-by: Masereel Pierre <pim@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
