### PR TITLE
[FIX] l10n_ke_edi_tremol: To send to TIMS filter

### DIFF
--- a/addons/l10n_ke_edi_tremol/views/account_move_view.xml
+++ b/addons/l10n_ke_edi_tremol/views/account_move_view.xml
@@ -50,6 +50,10 @@
                 <xpath expr="//field[@name='journal_id']" position="after">
                     <field name="l10n_ke_cu_invoice_number" string="Kenya CU Invoice Number" filter_domain="[('l10n_ke_cu_invoice_number', 'ilike', self')]" />
                 </xpath>
+                <xpath expr="//filter[@name='cancel']" position="after">
+                    <separator/>
+                    <filter name="l10n_ke_edi_to_send" string="To Send to TIMS" domain="[('l10n_ke_cu_invoice_number', '=', False), ('state', '=', 'posted'), ('move_type', 'in', ['out_invoice', 'out_refund']), ('country_code', '=', 'KE')]"/>
+                </xpath>
             </field>
         </record>
     </data>


### PR DESCRIPTION
It is important that users are able to filter by invoices that need to be posted to TIMS

This commit adds that filter in the account move tree view.

closes odoo/odoo#108641

Task-id: 2950308
X-original-commit: e19f0f478331e3c63833e791db42413e5b5a6684
Signed-off-by: Josse Colpaert <jco@odoo.com>
Signed-off-by: Daniel Kosky (dako) <dako@odoo.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
