### PR TITLE
[FIX] hr_timesheet: display timesheets without task in portal

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -256,11 +256,19 @@ class AccountAnalyticLine(models.Model):
         if self.env.user.has_group('hr_timesheet.group_hr_timesheet_user'):
             # Then, he is internal user, and we take the domain for this current user
             return self.env['ir.rule']._compute_domain(self._name)
-        return ['&',
+        return [
+            '|',
+                '&',
                     '|',
-                    ('task_id.project_id.message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id]),
-                    ('task_id.message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id]),
-                ('task_id.project_id.privacy_visibility', '=', 'portal')]
+                        ('task_id.project_id.message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id]),
+                        ('task_id.message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id]),
+                    ('task_id.project_id.privacy_visibility', '=', 'portal'),
+                '&',
+                    ('task_id', '=', False),
+                    '&',
+                        ('project_id.message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id]),
+                        ('project_id.privacy_visibility', '=', 'portal')
+        ]
 
     def _timesheet_preprocess(self, vals):
         """ Deduce other field values from the one given.


### PR DESCRIPTION
Issue:
When a project is shared with portal users,
only timesheets that are linked to tasks will be displayed.

Solution:
Change the domain that selects the timesheets to be displayed to take into account timesheets that are not linked to a task, but are in a project to which the portal user has access.

opw-3253632

closes odoo/odoo#118500

X-original-commit: 527033596afe5640533c568ea8c7367c40ff183a

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
