### PR TITLE
[FIX] pos_restaurant_stripe: always capture even with no tip

### DIFF
--- a/addons/pos_restaurant_stripe/static/src/overrides/app/tip_screen/tip_screen.js
+++ b/addons/pos_restaurant_stripe/static/src/overrides/app/tip_screen/tip_screen.js
@@ -1,0 +1,23 @@
+import { TipScreen } from "@pos_restaurant/app/screens/tip_screen/tip_screen";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(TipScreen.prototype, {
+    async validateTip() {
+        // Since we don't have any tip amount, we never send a capture request to Stripe.
+        // This means we need to manually capture the payment here if the tip amount is 0 or invalid,
+        // otherwise the order will be left in a "pending" state in Stripe and automatically cancelled.
+        if (!this.env.utils.parseValidFloat(this.state.inputTipAmount)) {
+            const paymentline = this.pos.getOrder().payment_ids[0];
+            if (
+                paymentline.payment_method_id.use_payment_terminal === "stripe" &&
+                paymentline.payment_method_id.payment_terminal
+            ) {
+                await paymentline.payment_method_id.payment_terminal.capturePayment(
+                    paymentline.transaction_id
+                );
+            }
+        }
+        return super.validateTip(...arguments);
+    },
+});


### PR DESCRIPTION
Currently, the pos_restaurant module only calls capture payment within validateTip if there is an amount to tip. Since Stripe requires a capture for all payments and we defer that to later if it can be adjusted, this means that if customers have tip after payment enabled and enter a tip of 0%, it will never be captured, stay pending, and then be automatically cancelled later down the line.

This commit catches that by hooking into the validateTip method and calling capture anyway on 0 charge tips.

opw-6082596

closes odoo/odoo#266242

X-original-commit: 2dadfa431c6b94e10c6aa524764bac3fe15ace25

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
